### PR TITLE
Block Patternで使用するiframe内でだけ別のテーマに変更できるようにしました

### DIFF
--- a/modules/content-part.php
+++ b/modules/content-part.php
@@ -42,25 +42,26 @@ function vkpdc_get_size_selector( $page_type = 'single' ) {
  * @return string $iframe_content : Iframe で表示する内容
  */
 function vkpdc_get_iframe_content( $post_id, $page_type = 'single' ) {
+    $iframe_wrapper  = 'vkpdc_iframe-wrapper';
+    if ( ! empty( $page_type ) ) {
+        $iframe_wrapper .= ' vkpdc_iframe-wrapper--' . $page_type;
+    }
 
-	$iframe_wrapper  = 'vkpdc_iframe-wrapper';
-	if ( ! empty( $page_type ) ) {
-		$iframe_wrapper .= ' vkpdc_iframe-wrapper--' . $page_type;
-	}
+    // 選択されたテーマを取得
+    $selected_theme = get_option( 'vkpdc_selected_theme', 'default' );
 
-	// 表示するテーマを設定
-	$view = vkpdc_iframe_view_theme();
+    // iframe の URL を生成
+    $url = get_permalink( $post_id ) . '?view=iframe';
+    if ( $selected_theme !== 'default' ) {
+        $url .= '&theme=' . urlencode( $selected_theme );
+    }
 
-	// Iframe の href に指定する url.
-	$url = get_permalink( $post_id ) . '?view=' . $view . '&reload=true';
+    // iframe の HTML を生成
+    $iframe_content  = '<div class="' . esc_attr( $iframe_wrapper ) . '">';
+    $iframe_content .= '<iframe class="vkpdc_iframe" src="' . esc_url( $url ) . '"></iframe>';
+    $iframe_content .= '</div>';
 
-	// Iframe で表示する要素の HTML.
-	$iframe_content  = '<div class="' . $iframe_wrapper . '">';
-	$iframe_content .= '<iframe class="vkpdc_iframe" src="' . $url . '"></iframe>';
-	$iframe_content .= '</div>';
-
-	// iframe 化した コンテンツを返す.
-	return $iframe_content;
+    return $iframe_content;
 }
 
 /**

--- a/modules/content-part.php
+++ b/modules/content-part.php
@@ -49,7 +49,11 @@ function vkpdc_get_iframe_content( $post_id, $page_type = 'single' ) {
     }
 
     // 表示するテーマを設定
-    $view = get_option( 'vkpdc_selected_theme', 'default' );
+	$view = get_option( 'vkpdc_selected_theme', '' );
+
+	if ( empty( $view ) ) {
+		$view = vkpdc_iframe_view_theme();
+	}
 
     // Iframe の href に指定する url.
     $url = get_permalink( $post_id ) . '?view=iframe';

--- a/modules/content-part.php
+++ b/modules/content-part.php
@@ -42,25 +42,29 @@ function vkpdc_get_size_selector( $page_type = 'single' ) {
  * @return string $iframe_content : Iframe で表示する内容
  */
 function vkpdc_get_iframe_content( $post_id, $page_type = 'single' ) {
+
     $iframe_wrapper  = 'vkpdc_iframe-wrapper';
     if ( ! empty( $page_type ) ) {
         $iframe_wrapper .= ' vkpdc_iframe-wrapper--' . $page_type;
     }
 
-    // 選択されたテーマを取得
-    $selected_theme = get_option( 'vkpdc_selected_theme', 'default' );
+    // 表示するテーマを設定
+    $view = get_option( 'vkpdc_selected_theme', 'default' );
 
     // iframe の URL を生成
     $url = get_permalink( $post_id ) . '?view=iframe';
-    if ( $selected_theme !== 'default' ) {
-        $url .= '&theme=' . urlencode( $selected_theme );
+    if ( $view !== 'default' ) {
+        $url .= '&theme=' . urlencode( $view );
     }
 
-    // iframe の HTML を生成
+    // Iframe の href に指定する url.
     $iframe_content  = '<div class="' . esc_attr( $iframe_wrapper ) . '">';
+
+	// Iframe で表示する要素の HTML.
     $iframe_content .= '<iframe class="vkpdc_iframe" src="' . esc_url( $url ) . '"></iframe>';
     $iframe_content .= '</div>';
 
+	// iframe 化した コンテンツを返す.
     return $iframe_content;
 }
 

--- a/modules/content-part.php
+++ b/modules/content-part.php
@@ -51,16 +51,14 @@ function vkpdc_get_iframe_content( $post_id, $page_type = 'single' ) {
     // 表示するテーマを設定
     $view = get_option( 'vkpdc_selected_theme', 'default' );
 
-    // iframe の URL を生成
+    // Iframe の href に指定する url.
     $url = get_permalink( $post_id ) . '?view=iframe';
     if ( $view !== 'default' ) {
         $url .= '&theme=' . urlencode( $view );
     }
 
-    // Iframe の href に指定する url.
-    $iframe_content  = '<div class="' . esc_attr( $iframe_wrapper ) . '">';
-
 	// Iframe で表示する要素の HTML.
+    $iframe_content  = '<div class="' . esc_attr( $iframe_wrapper ) . '">';
     $iframe_content .= '<iframe class="vkpdc_iframe" src="' . esc_url( $url ) . '"></iframe>';
     $iframe_content .= '</div>';
 

--- a/modules/iframe-theme-settings.php
+++ b/modules/iframe-theme-settings.php
@@ -3,14 +3,14 @@
  * 設定メニュー追加
  */
 function vkpdc_add_iframe_admin_menu() {
-    add_submenu_page(
-        'edit.php?post_type=vk-patterns',
-        __( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ),
-        __( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ),
-        'manage_options',
-        'vkpdc-iframe-settings',
-        'vkpdc_render_iframe_settings_page'
-    );
+	add_submenu_page(
+		'edit.php?post_type=vk-patterns',
+		__( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ),
+		__( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ),
+		'manage_options',
+		'vkpdc-iframe-settings',
+		'vkpdc_render_iframe_settings_page'
+	);
 }
 add_action( 'admin_menu', 'vkpdc_add_iframe_admin_menu' );
 
@@ -18,43 +18,43 @@ add_action( 'admin_menu', 'vkpdc_add_iframe_admin_menu' );
  * 管理画面の設定ページを表示
  */
 function vkpdc_render_iframe_settings_page() {
-    $selected_theme = get_option( 'vkpdc_selected_theme', '' );
-    $themes = wp_get_themes();
+	$selected_theme = get_option( 'vkpdc_selected_theme', '' );
+	$themes = wp_get_themes();
 
-    if ( isset( $_POST['vkpdc_theme'] ) ) {
-        check_admin_referer( 'vkpdc_save_iframe_settings' ); // Nonce名も変更
-        $selected_theme = sanitize_text_field( $_POST['vkpdc_theme'] );
-        update_option( 'vkpdc_selected_theme', $selected_theme );
-        echo '<div class="updated"><p>' . __( 'Settings saved.', 'vk-pattern-directory-creator' ) . '</p></div>';
-    }
+	if ( isset( $_POST['vkpdc_theme'] ) ) {
+		check_admin_referer( 'vkpdc_save_iframe_settings' ); // Nonce名も変更
+		$selected_theme = sanitize_text_field( $_POST['vkpdc_theme'] );
+		update_option( 'vkpdc_selected_theme', $selected_theme );
+		echo '<div class="updated"><p>' . __( 'Settings saved.', 'vk-pattern-directory-creator' ) . '</p></div>';
+	}
 
-    ?>
-    <div class="wrap">
-        <h1><?php _e( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ); ?></h1>
-        <p><?php _e( 'This setting allows you to select a theme to be applied within the iframe view. Use this when you want to display a theme different from the one currently active on your site.', 'vk-pattern-directory-creator' ); ?></p>
-        <form method="post" action="">
-            <?php wp_nonce_field( 'vkpdc_save_iframe_settings' ); ?>
-            <table class="form-table">
-                <tr>
-                    <th scope="row">
-                        <label for="vkpdc_theme"><?php _e( 'Select Theme for Iframe:', 'vk-pattern-directory-creator' ); ?></label>
-                    </th>
-                    <td>
-                        <select id="vkpdc_theme" name="vkpdc_theme">
-                            <option value=""><?php _e( 'Default', 'vk-pattern-directory-creator' ); ?></option>
-                            <?php foreach ( $themes as $theme_slug => $theme ) : ?>
-                                <option value="<?php echo esc_attr( $theme_slug ); ?>" <?php selected( $theme_slug, $selected_theme ); ?>>
-                                    <?php echo esc_html( $theme->get( 'Name' ) ); ?>
-                                </option>
-                            <?php endforeach; ?>
-                        </select>
-                    </td>
-                </tr>
-            </table>
-            <p>
-                <input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'vk-pattern-directory-creator' ); ?>">
-            </p>
-        </form>
-    </div>
-    <?php
+	?>
+	<div class="wrap">
+		<h1><?php _e( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ); ?></h1>
+		<p><?php _e( 'This setting allows you to select a theme to be applied within the iframe view. Use this when you want to display a theme different from the one currently active on your site.', 'vk-pattern-directory-creator' ); ?></p>
+		<form method="post" action="">
+			<?php wp_nonce_field( 'vkpdc_save_iframe_settings' ); ?>
+			<table class="form-table">
+				<tr>
+					<th scope="row">
+						<label for="vkpdc_theme"><?php _e( 'Select Theme for Iframe:', 'vk-pattern-directory-creator' ); ?></label>
+					</th>
+					<td>
+						<select id="vkpdc_theme" name="vkpdc_theme">
+							<option value=""><?php _e( 'Default', 'vk-pattern-directory-creator' ); ?></option>
+							<?php foreach ( $themes as $theme_slug => $theme ) : ?>
+								<option value="<?php echo esc_attr( $theme_slug ); ?>" <?php selected( $theme_slug, $selected_theme ); ?>>
+									<?php echo esc_html( $theme->get( 'Name' ) ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+					</td>
+				</tr>
+			</table>
+			<p>
+				<input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'vk-pattern-directory-creator' ); ?>">
+			</p>
+		</form>
+	</div>
+	<?php
 }

--- a/modules/iframe-theme-settings.php
+++ b/modules/iframe-theme-settings.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * 設定メニュー追加
+ */
+function vkpdc_add_iframe_admin_menu() {
+    add_submenu_page(
+        'edit.php?post_type=vk-patterns',
+        __( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ),
+        __( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ),
+        'manage_options',
+        'vkpdc-iframe-settings',
+        'vkpdc_render_iframe_settings_page'
+    );
+}
+add_action( 'admin_menu', 'vkpdc_add_iframe_admin_menu' );
+
+/**
+ * 管理画面の設定ページを表示
+ */
+function vkpdc_render_iframe_settings_page() {
+    $selected_theme = get_option( 'vkpdc_selected_theme', '' );
+    $themes = wp_get_themes();
+
+    if ( isset( $_POST['vkpdc_theme'] ) ) {
+        check_admin_referer( 'vkpdc_save_iframe_settings' ); // Nonce名も変更
+        $selected_theme = sanitize_text_field( $_POST['vkpdc_theme'] );
+        update_option( 'vkpdc_selected_theme', $selected_theme );
+        echo '<div class="updated"><p>' . __( 'Settings saved.', 'vk-pattern-directory-creator' ) . '</p></div>';
+    }
+
+    ?>
+    <div class="wrap">
+        <h1><?php _e( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ); ?></h1>
+        <form method="post" action="">
+            <?php wp_nonce_field( 'vkpdc_save_iframe_settings' ); ?>
+            <table class="form-table">
+                <tr>
+                    <th scope="row">
+                        <label for="vkpdc_theme"><?php _e( 'Select Theme for Iframe:', 'vk-pattern-directory-creator' ); ?></label>
+                    </th>
+                    <td>
+                        <select id="vkpdc_theme" name="vkpdc_theme">
+                            <option value=""><?php _e( 'Default', 'vk-pattern-directory-creator' ); ?></option>
+                            <?php foreach ( $themes as $theme_slug => $theme ) : ?>
+                                <option value="<?php echo esc_attr( $theme_slug ); ?>" <?php selected( $theme_slug, $selected_theme ); ?>>
+                                    <?php echo esc_html( $theme->get( 'Name' ) ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </td>
+                </tr>
+            </table>
+            <p>
+                <input type="submit" class="button-primary" value="<?php _e( 'Save Changes', 'vk-pattern-directory-creator' ); ?>">
+            </p>
+        </form>
+    </div>
+    <?php
+}

--- a/modules/iframe-theme-settings.php
+++ b/modules/iframe-theme-settings.php
@@ -31,6 +31,7 @@ function vkpdc_render_iframe_settings_page() {
     ?>
     <div class="wrap">
         <h1><?php _e( 'Iframe Theme Settings', 'vk-pattern-directory-creator' ); ?></h1>
+        <p><?php _e( 'This setting allows you to select a theme to be applied within the iframe view. Use this when you want to display a theme different from the one currently active on your site.', 'vk-pattern-directory-creator' ); ?></p>
         <form method="post" action="">
             <?php wp_nonce_field( 'vkpdc_save_iframe_settings' ); ?>
             <table class="form-table">

--- a/modules/iframe-view.php
+++ b/modules/iframe-view.php
@@ -75,7 +75,7 @@ add_action( 'after_setup_theme', 'vkpdc_theme_support' );
  * @param 
  */
 function vkpdc_delete_pattern_description( $content ) {
-	
+
 	// 投稿タイプが vk-patterns でない場合は処理を中断
 	if ( 'vk-patterns' !== get_post_type() ) {
 		return $content;

--- a/modules/iframe-view.php
+++ b/modules/iframe-view.php
@@ -75,7 +75,7 @@ add_action( 'after_setup_theme', 'vkpdc_theme_support' );
  * @param 
  */
 function vkpdc_delete_pattern_description( $content ) {
-    
+	
 	// 投稿タイプが vk-patterns でない場合は処理を中断
 	if ( 'vk-patterns' !== get_post_type() ) {
 		return $content;
@@ -87,7 +87,6 @@ function vkpdc_delete_pattern_description( $content ) {
 	return $content;
 
 }
-
 
 /**
  * Iframe 時に専用のテンプレートに切り替え
@@ -141,3 +140,60 @@ function vkpdc_load_iframe_template() {
 	exit;
 }
 add_filter( 'template_redirect', 'vkpdc_load_iframe_template', 2147483647 );
+
+/**
+ * iframe内 のテーマを切り替える関数
+ */
+function vkpdc_switch_theme_for_iframe() {
+	// iframe 判定 (URL パラメータ)
+	if ( ! isset( $_GET['view'] ) || sanitize_text_field( $_GET['view'] ) !== 'iframe' ) {
+		error_log( 'Not an iframe view. Exiting.' );
+		return;
+	}
+
+	// 選択されたテーマを取得
+	$selected_theme = isset( $_GET['theme'] ) ? sanitize_text_field( $_GET['theme'] ) : 'default';
+	if ( $selected_theme !== 'default' ) {
+		$theme = wp_get_theme( $selected_theme );
+		if ( $theme->exists() ) {
+			error_log( 'Switching to theme: ' . $theme->get( 'Name' ) );
+
+			// テーマ切り替えをiframe内に限定
+			add_filter( 'template_directory', function() use ( $theme ) {
+				return $theme->get_template_directory();
+			});
+
+			add_filter( 'stylesheet_directory', function() use ( $theme ) {
+				return $theme->get_stylesheet_directory();
+			});
+
+			add_filter( 'stylesheet', function() use ( $theme ) {
+				return $theme->get_stylesheet();
+			});
+
+			add_filter( 'template', function() use ( $theme ) {
+				return $theme->get_template();
+			});
+
+			// テーマ固有のリソース（スタイル・スクリプト）を登録
+			add_action( 'wp_enqueue_scripts', function() use ( $theme ) {
+				wp_enqueue_style( 'iframe-theme-style', $theme->get_stylesheet_directory_uri() . '/style.css', array(), null );
+
+				if ( file_exists( $theme->get_stylesheet_directory() . '/js/main.js' ) ) {
+					wp_enqueue_script( 'iframe-theme-script', $theme->get_stylesheet_directory_uri() . '/js/main.js', array(), null, true );
+				}
+			}, 20 );
+		} else {
+			error_log( 'Theme does not exist: ' . $selected_theme );
+		}
+	}
+
+	// テンプレートの表示処理をiframeに限定
+	add_filter( 'template_include', function( $template ) {
+		if ( isset( $_GET['view'] ) && $_GET['view'] === 'iframe' ) {
+			return locate_template( 'iframe-template.php' );
+		}
+		return $template;
+	});
+}
+add_action( 'setup_theme', 'vkpdc_switch_theme_for_iframe', 1 );

--- a/modules/iframe-view.php
+++ b/modules/iframe-view.php
@@ -145,9 +145,9 @@ add_filter( 'template_redirect', 'vkpdc_load_iframe_template', 2147483647 );
  * iframe内 のテーマを切り替える関数
  */
 function vkpdc_switch_theme_for_iframe() {
+
 	// iframe 判定 (URL パラメータ)
 	if ( ! isset( $_GET['view'] ) || sanitize_text_field( $_GET['view'] ) !== 'iframe' ) {
-		error_log( 'Not an iframe view. Exiting.' );
 		return;
 	}
 
@@ -156,7 +156,6 @@ function vkpdc_switch_theme_for_iframe() {
 	if ( $selected_theme !== 'default' ) {
 		$theme = wp_get_theme( $selected_theme );
 		if ( $theme->exists() ) {
-			error_log( 'Switching to theme: ' . $theme->get( 'Name' ) );
 
 			// テーマ切り替えをiframe内に限定
 			add_filter( 'template_directory', function() use ( $theme ) {
@@ -183,8 +182,6 @@ function vkpdc_switch_theme_for_iframe() {
 					wp_enqueue_script( 'iframe-theme-script', $theme->get_stylesheet_directory_uri() . '/js/main.js', array(), null, true );
 				}
 			}, 20 );
-		} else {
-			error_log( 'Theme does not exist: ' . $selected_theme );
 		}
 	}
 }

--- a/modules/iframe-view.php
+++ b/modules/iframe-view.php
@@ -187,13 +187,5 @@ function vkpdc_switch_theme_for_iframe() {
 			error_log( 'Theme does not exist: ' . $selected_theme );
 		}
 	}
-
-	// テンプレートの表示処理をiframeに限定
-	add_filter( 'template_include', function( $template ) {
-		if ( isset( $_GET['view'] ) && $_GET['view'] === 'iframe' ) {
-			return locate_template( 'iframe-template.php' );
-		}
-		return $template;
-	});
 }
 add_action( 'setup_theme', 'vkpdc_switch_theme_for_iframe', 1 );

--- a/vk-pattern-directory-creator.php
+++ b/vk-pattern-directory-creator.php
@@ -51,5 +51,8 @@ require_once $vkpdc_modules_path . 'content-archive.php';
 // アーカイブページ設定
 require_once $vkpdc_modules_path . 'content-archive-settings.php';
 
+// Iframe テーマ設定
+require_once $vkpdc_modules_path . 'iframe-theme-settings.php';
+
 // ブロック
 require_once $vkpdc_modules_path . 'blocks.php';


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-pattern-directory-creator/pull/9#issuecomment-2570149385

## どういう変更をしたか？

### 管理画面で iframe 用テーマを選択

- 管理画面 から Block Pattern > Iframe Theme Settings にて設定できます。
- サイトにインストールされているテーマから選択可能。
- デフォルト設定では現在のテーマが適用されるが、他のテーマを選択して保存することで iframe 内にそのテーマを適用できます。

### iframe 内でテーマを動的に切り替え
- iframe 内では、iframe の URL に ?view=iframe&theme=twentytwentyfive のようにテーマ名を含めることで、そのテーマを動的に適用。
- テンプレート、CSS、JS などのリソースが選択したテーマに基づいて完全に切り替わります。
- 他の投稿やページには影響を与えません。
- 無効なテーマ名や存在しないテーマ名を指定した場合、エラーが出力されず、デフォルトテーマが適用されます。

## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [ ] readme.txt に変更内容は書いたか？ →スキップ
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [ ] 書けそうなテストは書いたか？ →スキップ


## 変更内容について何を確認したか、どういう方法で確認をしたかなど


## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
